### PR TITLE
Fix bin

### DIFF
--- a/bin/apk-mitm
+++ b/bin/apk-mitm
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('../dist/cli')

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apk-mitm",
   "description": "A CLI application that automatically prepares Android APK files for HTTPS inspection",
   "main": "dist/index.js",
-  "repository": "shroudedcode/apk-mitm",
+  "repository": "umbrageodotus/apk-mitm",
   "keywords": [
     "cli",
     "reverse engineering",
@@ -20,9 +20,7 @@
     "format": "prettier --write .",
     "lint": "prettier --check ."
   },
-  "bin": "bin/apk-mitm",
   "files": [
-    "bin",
     "dist"
   ],
   "engines": {


### PR DESCRIPTION
- **Initial commit**
- **Add "test" script for `np`**
- **v0.1.0**
- **Add `executeJar` helper function**
- **Add description and keywords to `package.json`**
- **Improve README**
- **Rename `updateManifest` function to match task title**
- **v0.1.1**
- **Set `repository` in `package.json`**
- **v0.1.2**
- **Fix broken links in README**
- **Tweak description**
- **Tweak README**
- **v0.1.3**
- **Fix typo in description**
- **v0.1.4**
- **Always use AAPT2 for encoding**
- **Update Apktool**
- **v0.2.0**
- **Remove "I: " prefix from Apktool logs**
- **Shorten arrow function syntax**
- **v0.2.1**
- **Make sure `res/xml` directory exists before writing Network Security Config**
- **v0.2.2**
- **Add `--apktool` option to enable usage of custom Apktool versions**
- **v0.3.0**
- **Remove certificate pinning rules from Network Security Config**
- **Use XML compact mode for modifying manifest**
- **Fall back to using AAPT when encoding using AAPT2 fails**
- **Show warning when Android App Bundle is detected**
- **v0.4.0**
- **Exit with successful status code when `--help` is used**
- **Print help to stdout instead of stderr**
- **Implement Android App Bundle support (#7)**
- **Remove Android App Bundle caveat**
- **Document Android App Bundle support in README**
- **v0.5.0**
- **Add `.zip` alias for `.apks` format**
- **Only show App Bundle warning after patching single APK**
- **v0.5.1**
- **Update dependencies**
- **v0.5.2**
- **Patch certificate pinning methods that are `final`**
- **v0.5.3**
- **Use `@tybys/cross-zip` fork instead of `cross-zip`**
- **v0.5.4**
- **Speed up glob pattern for finding smali files**
- **v0.5.5**
- **Add `--wait` option**
- **v0.6.0**
- **Update Apktool to v2.4.1**
- **v0.6.1**
- **Log stderr output when commands fail**
- **v0.6.2**
- **Remove unused `cross-zip` dependency**
- **Update dependencies**
- **Use `recursive` option of `fs.mkdir()` instead of `mkdirp` package**
- **Use native Promise versions of `fs` functions where possible**
- **Remove stub type definitions**
- **v0.6.3**
- **Fix typo in README**
- **Update dependencies**
- **Require Node.js 10**
- **v0.6.4**
- **Prevent issues with Apktool framework files by using custom directory**
- **Download and cache tools at runtime instead of bundling them**
- **v0.7.0**
- **Fix link to mitmproxy in README**
- **v0.7.1**
- **Make error output easier to parse**
- **Update dependencies**
- **Show note about ARM incompatibility when patching fails**
- **v0.8.0**
- **Disable certificate pinning more reliably**
- **Speed up patching by not scanning all classes for certificate pinning**
- **Update OWASP links in README**
- **v0.8.1**
- **Output full logs of all processes in temporary directory**
- **v0.9.0**
- **Update dependencies**
- **Update `uber-apk-signer` to v1.2.1**
- **Improve error handling in `downloadFile` function**
- **Fix unhandled promise rejection**
- **Add `apk-mitm-` prefix to temporary directory name**
- **v0.9.1**
- **Update Apktool to v2.5.0**
- **v0.9.2**
- **Fix certificate pinning removal not working on Windows**
- **v0.9.3**
- **Remove unused `jar` directory from `package.json`**
- **Create Network Security Config based on hard-coded template file**
- **Allow cleartext traffic in Network Security Config**
- **v0.9.4**
- **Fix inconsistent indentation in full logs message**
- **Print full stack trace for non-command errors**
- **Fix inconsistent indentation in `observe-process.ts`**
- **Introduce `observeAsync` helper to improve async error handling**
- **Use `fs` wrapper everywhere**
- **Use `globby.stream` for finding Smali files**
- **v0.9.5**
- **Set up automatic code formatting using Prettier**
- **Configure recommended VS Code workspace extensions**
- **Stop setting `debuggable` attribute to `true` in manifest**
- **Group all patches into one task**
- **Add `--skip-patches` flag**
- **Disable `esModuleInterop` TypeScript compiler option**
- **Start emitting TypeScript declarations**
- **Make logging of `disableCertificatePinning` function less verbose**
- **Introduce `observeListr` helper function**
- **Expose `observeListr` and `applyPatches` functions as library**
- **v0.10.0**
- **Inline NSC XML template**
- **v0.10.1**
- **Enable TypeScript strict mode**
- **Create `processSmaliFile` function**
- **Implement new Smali patching logic**
- **Rename `next` functions to `log` in most places**
- **Stop using `xml-js` compact mode for modifying manifest**
- **v0.11.0**
- **Explicitly allow system certificates in Network Security Config**
- **Mention APKLab in README**
- **Fix spelling of "APKLab"**
- **Make `observeListr` function show task progress**
- **v0.11.1**
- **Add CLI option to mark app as debuggable (#35)**
- **Set up continuous integration (#39)**
- **Explicitly install types for the lowest supported Node.js version**
- **Add ponyfill for `String.prototype.matchAll`**
- **v0.12.0**
- **Add prerequisite checks**
- **Drop support for Node.js 10**
- **Recommend regular installation (instead of `npx`) in README**
- **Update dependencies**
- **v1.0.0**
- **Fix Java version check failing when it can only find a major version**
- **v1.0.1**
- **Update dependencies**
- **Document dependency on and check existence of `zip` and `unzip`on Linux**
- **Implement `UserError` class for errors that don't require a stack trace**
- **v1.0.2**
- **Fix App Bundle APKs not being properly signed on Windows**
- **v1.0.3**
- **Implement `--certificate` flag (#64)**
- **Update Apktool to v2.6.0**
- **v1.1.0**
- **Add troubleshooting guide on patching failures**
- **Add troubleshooting guide on reading logs**
- **Add `--keep` cli argument to keep temporary directory (#91)**
- **Also enable GitHub Actions for pull requests**
- **Add macOS and Node.js 16 to GitHub Actions test matrix**
- **Reorder GitHub action jobs**
- **Ignore `EBUSY` error when deleting temporary directory under Windows**
- **Add support for user-defined temporary directory path (#79)**
- **Rename `--keep` flag to `--keep-tmp-dir`**
- **v1.2.0**
- **Bump apktool from 2.6.0 to 2.6.1 (#94)**
- **v1.2.1**
- **Add support for patching an unpacked apk (#97)**
- **Add cli option to replace google maps api key (#98)**
- **Make sure files extracted from zip files have the right Unix permissions**
- **Move logic to determine task type into separate function**
- **Throw error when input directory does not contain an `apktool.yml` file**
- **Shorten "decoded-directory-by-apktool" in CLI output**
- **Update apktool to v2.9.3**
- **Make shell commands in README easier to copy (#114)**
- **Clean up handling of relative input paths**
- **Update uber-apk-signer to v1.3.0**
- **Fix `--apktool` accidentally being required**
- **Fix `--certificate` only working with `.pem` files**
- **Add "Limitations & alternatives" section to README**
- **v1.3.0**
- **Update apktool**
- **Fix XML**
- **Remove patch file**
- **Fix repository**
